### PR TITLE
refactor: use forwardRef in MovieCard

### DIFF
--- a/src/components/MovieCard.tsx
+++ b/src/components/MovieCard.tsx
@@ -3,54 +3,56 @@ import styles from "./MovieCard.module.css";
 import { useNavigate } from "react-router";
 import { useFavorites } from "../hooks/useFavorites";
 import image from "../assets/placeHolder.png";
+import { forwardRef, type Ref } from "react";
 
 interface Props {
   movie: Movie;
-  ref?: React.Ref<HTMLDivElement>;
 }
 
-export function MovieCard({ movie, ref }: Props) {
-  const { isFav, toggleFav } = useFavorites();
-  const navigate = useNavigate();
-  const handleMovieClick = (id: string) => {
-    navigate(`/movie/${id}`);
-  };
+export const MovieCard = forwardRef<HTMLDivElement, Props>(
+  ({ movie }, ref: Ref<HTMLDivElement>) => {
+    const { isFav, toggleFav } = useFavorites();
+    const navigate = useNavigate();
+    const handleMovieClick = (id: string) => {
+      navigate(`/movie/${id}`);
+    };
 
-  return (
-    <article
-      className={`${styles.Pelicula}`}
-      ref={ref}
-      data-aos="fade-up"
-      data-aos-duration="1000"
-      data-aos-easing="ease-in-out"
-    >
-      <img
-        src={movie.Poster === "N/A" ? image : movie.Poster}
-        alt={movie.Title}
-        onError={(e) => {
-          e.currentTarget.src = image;
-        }}
-        onClick={() => {
-          handleMovieClick(movie.imdbID);
-        }}
-      />
-      <section>
-        <h2>{movie.Title}</h2>
-        <p>{movie.Year}</p>
-        <button
-          className={`${styles.favoriteButton} ${
-            isFav(movie.imdbID) ? styles.fav : styles.notFav
-          }`}
-          onClick={() => toggleFav(movie)}
-          aria-label={
-            isFav(movie.imdbID)
-              ? "Remove from favorites"
-              : "Add to favorites"
-          }
-        >
-          {isFav(movie.imdbID) ? "♥" : "♡"}
-        </button>
-      </section>
-    </article>
-  );
-}
+    return (
+      <article
+        className={`${styles.Pelicula}`}
+        ref={ref}
+        data-aos="fade-up"
+        data-aos-duration="1000"
+        data-aos-easing="ease-in-out"
+      >
+        <img
+          src={movie.Poster === "N/A" ? image : movie.Poster}
+          alt={movie.Title}
+          onError={(e) => {
+            e.currentTarget.src = image;
+          }}
+          onClick={() => {
+            handleMovieClick(movie.imdbID);
+          }}
+        />
+        <section>
+          <h2>{movie.Title}</h2>
+          <p>{movie.Year}</p>
+          <button
+            className={`${styles.favoriteButton} ${
+              isFav(movie.imdbID) ? styles.fav : styles.notFav
+            }`}
+            onClick={() => toggleFav(movie)}
+            aria-label={
+              isFav(movie.imdbID)
+                ? "Remove from favorites"
+                : "Add to favorites"
+            }
+          >
+            {isFav(movie.imdbID) ? "♥" : "♡"}
+          </button>
+        </section>
+      </article>
+    );
+  }
+);


### PR DESCRIPTION
## Summary
- refactor MovieCard to use React.forwardRef and remove ref from props

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, React hooks rule violations, react-refresh/only-export-components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce863f40832f873c5dc668279065