### PR TITLE
fix: handle missing mock query parameters

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -29,6 +29,7 @@ export const handlers = [
         ],
       });
     }
+
     if (id) {
       return HttpResponse.json({
         Title: "Mock Movie by ID",
@@ -38,10 +39,11 @@ export const handlers = [
         Poster: "N/A",
         Response: "True",
       });
-      return HttpResponse.json(
-        { Response: "False", Error: "Missing query" },
-        { status: 400 }
-      );
     }
+
+    return HttpResponse.json(
+      { Response: "False", Error: "Missing query" },
+      { status: 400 }
+    );
   }),
 ];


### PR DESCRIPTION
## Summary
- remove unreachable error response inside `if (id)` mock handler
- add default `Missing query` response when no parameters are provided

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any... and react hooks issues)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce95b460832fa3ae3590e08d2804