### PR TITLE
Fix vi.clearAllMocks call in Movie tests

### DIFF
--- a/src/pages/Movie.test.tsx
+++ b/src/pages/Movie.test.tsx
@@ -35,7 +35,7 @@ describe("Movie", () => {
   );
 
   beforeAll(() => {
-    vi.clearAllMocks;
+    vi.clearAllMocks();
   });
 
   test("should render Movie component", () => {


### PR DESCRIPTION
## Summary
- fix missing vi.clearAllMocks() call in Movie tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6894ce9926c0832fb0c9e4314ccbe25e