### PR TITLE
refactor: handle caching in hook

### DIFF
--- a/src/hooks/useMovies.test.tsx
+++ b/src/hooks/useMovies.test.tsx
@@ -6,6 +6,7 @@ import * as debounce from "./useDebouncedValue";
 import * as intersection from "./useIntersectionObserver";
 import * as omdb from "../services/omdb";
 import type { OmdbSearchResult } from "../models/omdb";
+import type { ReactNode } from "react";
 
 vi.mock("./useDebouncedValue");
 vi.mock("./useIntersectionObserver");
@@ -21,7 +22,7 @@ describe("useMovies", () => {
   const filtrarPeliculasUnicas = vi.mocked(omdb.filtrarPeliculasUnicas);
 
   const setLastpage = vi.fn();
-  const wrapper = ({ children }: any) => (
+  const wrapper = ({ children }: { children: ReactNode }) => (
     <Context.Provider
       value={{ fav: [], setFav: vi.fn(), lastPage: "", setLastpage }}
     >
@@ -74,7 +75,7 @@ describe("useMovies", () => {
       expect(result.current.data).toEqual(movieData);
     });
 
-    expect(getMovies).toHaveBeenCalledWith("Batman", 1, {});
+    expect(getMovies).toHaveBeenCalledWith("Batman", 1);
     expect(setLastpage).toHaveBeenCalledWith("Batman");
   });
 

--- a/src/hooks/useMovies.tsx
+++ b/src/hooks/useMovies.tsx
@@ -46,17 +46,34 @@ export const useMovies = (movie = "") => {
 
   useEffect(() => {
     if (!pelicula) return;
+    const clave = `${pelicula}-${page}`;
+
+    if (cache[clave]) {
+      const dataCache = cache[clave];
+      setData((prev) => {
+        if (!prev || page === 1) return dataCache;
+
+        return {
+          ...dataCache,
+          Search: [
+            ...prev.Search,
+            ...(dataCache.Search
+              ? filtrarPeliculasUnicas(prev.Search, dataCache.Search)
+              : []),
+          ],
+        };
+      });
+      return;
+    }
+
     setLoading(true);
-    getMovies(pelicula, page, cache)
+    getMovies(pelicula, page)
       .then((data) => {
         if (data) {
-          const clave = `${pelicula}-${page}`;
-          if (!cache[clave]) {
-            setCache((prev) => ({
-              ...prev,
-              [clave]: data,
-            }));
-          }
+          setCache((prev) => ({
+            ...prev,
+            [clave]: data,
+          }));
 
           setData((prev) => {
             if (!prev || page === 1) return data;

--- a/src/services/omdb.test.ts
+++ b/src/services/omdb.test.ts
@@ -22,7 +22,7 @@ afterAll(() => {
 
 describe("OMDB API", () => {
   test("should return movies", async () => {
-    const response = getMovies("mock", 1, {});
+    const response = getMovies("mock", 1);
 
     const data = await response;
     if (!data) return;
@@ -69,7 +69,7 @@ describe("OMDB API", () => {
   });
 
   test("has more should return true", async () => {
-    const response = getMovies("mock", 1, {});
+    const response = getMovies("mock", 1);
 
     const data = await response;
     if (!data) return;

--- a/src/services/omdb.ts
+++ b/src/services/omdb.ts
@@ -8,15 +8,8 @@ export const api = "https://www.omdbapi.com/";
 
 export const getMovies = (
   pelicula: string,
-  page: number,
-  cache: Record<string, OmdbSearchResult>
+  page: number
 ): Promise<OmdbSearchResult | undefined> => {
-  const claveCache = `${pelicula}-${page}`;
-
-  if (cache[claveCache]) {
-    return Promise.resolve(cache[claveCache]);
-  }
-
   return fetch(
     `${api}?s=${pelicula}&page=${page}&apikey=${import.meta.env.VITE_API_KEY}`
   )


### PR DESCRIPTION
## Summary
- remove cache parameter from `getMovies`
- manage movie result caching within `useMovies` hook
- adjust tests for new `getMovies` signature

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: React Hook missing dependencies and existing any type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce9dd6cc832fa1ca50d278bedd0f