### PR TITLE
Manejar errores HTTP en getMovieById

### DIFF
--- a/src/services/omdb.ts
+++ b/src/services/omdb.ts
@@ -42,10 +42,17 @@ export const filtrarPeliculasUnicas = (
   return nuevas.filter((p) => !ids.has(p.imdbID));
 };
 
-export const getMovieById = (id: string) => {
+export const getMovieById = (
+  id: string
+): Promise<OmdbMovieDetails | undefined> => {
   return fetch(`${api}?i=${id}&apikey=${import.meta.env.VITE_API_KEY}`)
-    .then((response) => response.json())
-    .then((data) => data)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data: OmdbMovieDetails) => data)
     .catch((error) => {
       console.error("Error al obtener datos de OMDb:", error);
       return undefined;


### PR DESCRIPTION
## Summary
- Tipar getMovieById para devolver `Promise<OmdbMovieDetails | undefined>`
- Verificar `response.ok` y lanzar error antes de parsear JSON

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, no-unused-expressions, etc. in test files)*


------
https://chatgpt.com/codex/tasks/task_e_6894cea306f0832f87ca5438bf100bf9