### PR TITLE
Clear movies when search is cleared

### DIFF
--- a/src/hooks/useMovies.test.tsx
+++ b/src/hooks/useMovies.test.tsx
@@ -135,4 +135,74 @@ describe("useMovies", () => {
     expect(result.current.data?.Search[0]).toEqual(page1.Search[0]);
     expect(result.current.data?.Search[1]).toEqual(page2.Search[0]);
   });
+
+  test("should clear movies when search is cleared", async () => {
+    const movieData: OmdbSearchResult = {
+      Search: [
+        {
+          Title: "Test Movie",
+          Year: "2022",
+          imdbID: "tt1234567",
+          Type: "movie",
+          Poster: "https://example.com/poster.jpg",
+        },
+      ],
+      totalResults: "1",
+      Response: "True",
+    };
+    getMovies.mockResolvedValueOnce(movieData);
+
+    const { result } = renderHook(() => useMovies(), { wrapper });
+
+    act(() => {
+      result.current.setSearch("Batman");
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(movieData);
+    });
+
+    act(() => {
+      result.current.setSearch("");
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeNull();
+    });
+    expect(setLastpage).toHaveBeenCalledWith("");
+    expect(window.location.pathname).toBe("/");
+  });
+
+  test("should reset movies when navigating to home", async () => {
+    const movieData: OmdbSearchResult = {
+      Search: [
+        {
+          Title: "Test Movie",
+          Year: "2022",
+          imdbID: "tt1234567",
+          Type: "movie",
+          Poster: "https://example.com/poster.jpg",
+        },
+      ],
+      totalResults: "1",
+      Response: "True",
+    };
+    getMovies.mockResolvedValueOnce(movieData);
+
+    const { result, rerender } = renderHook(
+      ({ movie }: { movie: string }) => useMovies(movie),
+      { initialProps: { movie: "Batman" }, wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(movieData);
+    });
+
+    rerender({ movie: "" });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeNull();
+    });
+    expect(setLastpage).toHaveBeenCalledWith("");
+  });
 });

--- a/src/hooks/useMovies.tsx
+++ b/src/hooks/useMovies.tsx
@@ -22,6 +22,14 @@ export const useMovies = (movie = "") => {
   const { setLastpage } = ctx;
 
   useEffect(() => {
+    setPelicula(movie);
+    if (movie === "") {
+      setSearch("");
+      setLastpage("");
+    }
+  }, [movie]);
+
+  useEffect(() => {
     if (debounceSearch === "" || search === "") return;
     setPelicula(debounceSearch);
     setLastpage(debounceSearch);
@@ -39,7 +47,6 @@ export const useMovies = (movie = "") => {
   });
 
   useEffect(() => {
-    if (!pelicula) return;
     setData(null); // Limpia resultados anteriores
     setPage(1); // Reinicia la paginación
   }, [pelicula]);
@@ -99,6 +106,13 @@ export const useMovies = (movie = "") => {
   }, [pelicula, page]);
 
   const handleSearch = (value: string) => {
+    if (value === "") {
+      setSearch("");
+      setPelicula("");
+      setLastpage("");
+      window.history.replaceState(null, "", "/");
+      return;
+    }
     if (value.length < 3) {
       return;
     }


### PR DESCRIPTION
## Summary
- reset search state when URL param or input is empty
- clear movie results and pagination on empty search
- add tests for clearing search and navigating home

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6895089d1cdc832f95cec70f65ac517c