### PR TITLE
feat: Allow API key to be set at runtime via Docker env

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -28,4 +28,16 @@ COPY --from=builder /app/dist /usr/share/caddy
 # y lo copias así:
 COPY Caddyfile /etc/caddy/Caddyfile
 
+# Copiamos el entrypoint script
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Hacemos el entrypoint script ejecutable
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Exponemos la variable de entorno
+ENV APIKEY=""
+
+# Establecemos el entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 # Por defecto, Caddy servirá /usr/share/caddy en el puerto 80

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script>
+      window.API_KEY = "__API_KEY__";
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Reemplaza el placeholder __API_KEY__ con el valor de la variable de entorno APIKEY
+# en el archivo index.html
+sed -i "s|__API_KEY__|${APIKEY}|g" /usr/share/caddy/index.html
+
+# Ejecuta el comando original de Caddy
+exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/src/services/omdb.ts
+++ b/src/services/omdb.ts
@@ -11,7 +11,7 @@ export const getMovies = (
   page: number
 ): Promise<OmdbSearchResult | undefined> => {
   return fetch(
-    `${api}?s=${pelicula}&type=movie&page=${page}&apikey=${import.meta.env.VITE_API_KEY}`
+    `${api}?s=${pelicula}&type=movie&page=${page}&apikey=${window.API_KEY}`
   )
     .then((response) => response.json())
     .then((data: OmdbSearchResult) => data)
@@ -57,7 +57,7 @@ export const filtrarPeliculasUnicas = (
 export const getMovieById = (
   id: string
 ): Promise<OmdbMovieDetails | undefined> => {
-  return fetch(`${api}?i=${id}&apikey=${import.meta.env.VITE_API_KEY}`)
+  return fetch(`${api}?i=${id}&apikey=${window.API_KEY}`)
     .then((response) => {
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  API_KEY: string;
+}


### PR DESCRIPTION
This commit introduces a mechanism to allow the OMDb API key to be set at runtime via a Docker environment variable named APIKEY.

This is achieved by:
- Introducing a placeholder `__API_KEY__` in a <script> tag within index.html. This placeholder is assigned to a global `window.API_KEY` variable.
- Creating an `entrypoint.sh` script for the Docker container. This script runs before the web server starts and uses `sed` to replace the `__API_KEY__` placeholder in index.html with the actual value of the `$APIKEY` environment variable passed to the container.
- Updating the `dockerfile` to copy and execute this new entrypoint script.
- Modifying the API service calls in the TypeScript code to use `window.API_KEY` instead of the build-time variable `import.meta.env.VITE_API_KEY`.